### PR TITLE
Bump gradle build action to v3

### DIFF
--- a/.github/actions/setup-android-build/action.yml
+++ b/.github/actions/setup-android-build/action.yml
@@ -11,7 +11,7 @@ runs:
         java-version: 17
 
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2.7.0
+      uses: gradle/actions/setup-gradle@v3
       with:
         generate-job-summary: false
         gradle-home-cache-strict-match: true


### PR DESCRIPTION
Release notes: https://github.com/gradle/gradle-build-action/releases/tag/v3.0.0