### PR TITLE
Remove build flavors

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: ./.github/actions/setup-android-build
 
       - name: Run Tests
-        run: ./gradlew testDebugUnitTest testPinboardapiDebugUnitTest --stacktrace
+        run: ./gradlew testDebugUnitTest --stacktrace
 
   build:
     name: Build
@@ -32,13 +32,13 @@ jobs:
         uses: ./.github/actions/setup-android-build
 
       - name: Build
-        run: ./gradlew assemblePinboardapi --stacktrace
+        run: ./gradlew assemble --stacktrace
 
-      - name: Upload Pinboard API APK
+      - name: Upload APK
         if: success()
         uses: actions/upload-artifact@v4
         with:
-          path: app/build/outputs/apk/pinboardapi/debug/*.apk
+          path: app/build/outputs/apk/debug/*.apk
 
   instrumented_tests:
     name: Instrumented Tests
@@ -66,7 +66,7 @@ jobs:
         run: yes | "$ANDROID_HOME"/cmdline-tools/latest/bin/sdkmanager --licenses || true
 
       - name: Run instrumented tests
-        run: ./gradlew pixel8api34PinboardapiDebugAndroidTest
+        run: ./gradlew pixel8api34DebugAndroidTest
           -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect"
           -Pandroid.experimental.androidTest.numManagedDeviceShards=1
           -Pandroid.experimental.testOptions.managedDevices.maxConcurrentDevices=1

--- a/.github/workflows/signed-build.yml
+++ b/.github/workflows/signed-build.yml
@@ -23,7 +23,7 @@ jobs:
           echo "${{ secrets.KEYSTORE }}" | base64 -d > ${{ github.workspace }}/keystore/release.jks
 
       - name: Build
-        run: ./gradlew app:assemblePinboardapiRelease
+        run: ./gradlew app:assembleRelease
         env:
           SIGN_BUILD: true
           SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
@@ -35,7 +35,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: signed-apk
-          path: app/build/outputs/apk/pinboardapi/release/*.apk
+          path: app/build/outputs/apk/release/*.apk
 
   build-signed-aab:
     name: Build Signed AAB
@@ -53,7 +53,7 @@ jobs:
           echo "${{ secrets.KEYSTORE }}" | base64 -d > ${{ github.workspace }}/keystore/release.jks
 
       - name: Build
-        run: ./gradlew app:bundlePinboardapiRelease
+        run: ./gradlew app:bundleRelease
         env:
           SIGN_BUILD: true
           SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
@@ -65,4 +65,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: signed-aab
-          path: app/build/outputs/bundle/pinboardapiRelease/*.aab
+          path: app/build/outputs/bundle/release/*.aab

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -100,18 +100,6 @@ android {
         }
     }
 
-    flavorDimensions.add("api")
-    productFlavors {
-        create("pinboardapi") {
-            dimension = "api"
-        }
-
-        create("noapi") {
-            dimension = "api"
-            applicationIdSuffix = ".noapi"
-        }
-    }
-
     sourceSets {
         forEach { sourceSet -> getByName(sourceSet.name).java.srcDirs("src/${sourceSet.name}/kotlin") }
 
@@ -144,7 +132,6 @@ androidComponents {
         val appName =
             StringBuilder().apply {
                 append(AppInfo.APP_NAME)
-                if (variant.name.contains("noapi", ignoreCase = true)) append(" NoApi")
                 if (variant.name.contains("debug", ignoreCase = true)) append(" Dev")
             }.toString()
 

--- a/app/src/main/kotlin/com/fibelatti/pinboard/core/AppModeProvider.kt
+++ b/app/src/main/kotlin/com/fibelatti/pinboard/core/AppModeProvider.kt
@@ -1,6 +1,5 @@
 package com.fibelatti.pinboard.core
 
-import com.fibelatti.pinboard.BuildConfig
 import com.fibelatti.pinboard.core.di.AppDispatchers
 import com.fibelatti.pinboard.core.di.Scope
 import com.fibelatti.pinboard.features.user.domain.UserRepository
@@ -25,12 +24,11 @@ class AppModeProvider @Inject constructor(
     ) { preferences, authToken -> getValue(preferences.useLinkding, authToken) }
         .stateIn(scope, sharingStarted, getValue())
 
-    @Suppress("KotlinConstantConditions")
     private fun getValue(
         useLinkding: Boolean = userRepository.useLinkding,
         authToken: String = userRepository.authToken.value,
     ): AppMode = when {
-        BuildConfig.FLAVOR == "noapi" || authToken == "app_review_mode" -> AppMode.NO_API
+        authToken == "app_review_mode" -> AppMode.NO_API
         authToken.isBlank() -> AppMode.UNSET
         useLinkding -> AppMode.LINKDING
         else -> AppMode.PINBOARD

--- a/app/src/noapi/res/values/strings.xml
+++ b/app/src/noapi/res/values/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <!-- User Preferences -->
-    <string name="user_preferences_default_read_later_description">If checked, links shared to Pinkt will be saved as read later</string>
-</resources>

--- a/update-libraries-json.sh
+++ b/update-libraries-json.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-./gradlew app:exportLibraryDefinitions -PaboutLibraries.exportPath=src/main/res/raw/ -PaboutLibraries.exportVariant=pinboardapiRelease
+./gradlew app:exportLibraryDefinitions -PaboutLibraries.exportPath=src/main/res/raw/ -PaboutLibraries.exportVariant=release


### PR DESCRIPTION
## Summary
Product flavors were introduced very early in the codebase to facilitate using the app without any external provider (via the `noapi` flavor). That's was rarely used and it's no longer needed, so this removed flavors altogether.


## Changes
- Remove flavors from the app module
- Update `AppModeProvider` to remove redundant check
- Remove no longer needed string override
- Update GHA workflow files
- Update libraries script